### PR TITLE
fix: stop runaway sync commit loop

### DIFF
--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -10,10 +10,27 @@ from datetime import datetime, timezone
 
 REPO_PATH = os.environ.get("REPO_PATH", "/app/repo")
 
+COMMIT_PREFIX = "sync: update playing list"
+MAX_SYNC_COMMITS = int(os.environ.get("DEPLOY_MAX_SYNC_COMMITS", "10"))
+SYNC_WINDOW_MINUTES = int(os.environ.get("DEPLOY_SYNC_WINDOW_MINUTES", "60"))
+
 
 def run_git(*args: str, check: bool = True) -> subprocess.CompletedProcess:
     cmd = ["git", "-C", REPO_PATH, *args]
     return subprocess.run(cmd, capture_output=True, text=True, check=check)
+
+
+def recent_sync_commits() -> int:
+    result = run_git(
+        "log",
+        f"--since={SYNC_WINDOW_MINUTES} minutes ago",
+        f"--grep=^{COMMIT_PREFIX}",
+        "--oneline",
+        check=False,
+    )
+    if result.returncode != 0:
+        return 0
+    return len([line for line in result.stdout.splitlines() if line.strip()])
 
 
 def deploy() -> None:
@@ -27,6 +44,16 @@ def deploy() -> None:
     print(f"[deploy] {len(changed)} file(s) changed:")
     for line in changed:
         print(f"  {line}")
+
+    recent = recent_sync_commits()
+    if recent >= MAX_SYNC_COMMITS:
+        print(
+            f"[deploy] Circuit breaker tripped: {recent} sync commits in the last "
+            f"{SYNC_WINDOW_MINUTES}m (limit {MAX_SYNC_COMMITS}). Refusing to commit. "
+            f"Something is rewriting files on every run — inspect the working tree.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
     # Stage all tracked + new files the generator would have touched
     run_git("add", "index.html", "games.json")

--- a/scripts/guide_gen.py
+++ b/scripts/guide_gen.py
@@ -164,10 +164,12 @@ def assemble(slug: str, title: str, vndb_id: str, completed_routes: list[dict],
     # Preserve portrait and reviewed status already in guide.json
     existing_portraits: dict[str, str] = {}
     existing_reviewed: dict[str, bool] = {}
+    existing_data: dict | None = None
     existing_guide = guide_dir / "guide.json"
     if existing_guide.exists():
         try:
             existing = json.loads(existing_guide.read_text())
+            existing_data = existing
             for r in existing.get("routes", []):
                 if r.get("portrait"):
                     existing_portraits[r["id"]] = r["portrait"]
@@ -195,8 +197,17 @@ def assemble(slug: str, title: str, vndb_id: str, completed_routes: list[dict],
         "vndb_id": vndb_id,
         "routes": route_list,
         "sources": research.get("sources", []),
-        "generated_at": datetime.now(timezone.utc).isoformat(),
     }
+
+    # Rewriting generated_at on every pass would dirty the tree each run and make
+    # deploy.py commit forever, so only touch the file when content actually changed.
+    if existing_data is not None:
+        prior = {k: v for k, v in existing_data.items() if k != "generated_at"}
+        if prior == guide_data:
+            log("guide.json unchanged, keeping existing generated_at")
+            return
+
+    guide_data["generated_at"] = datetime.now(timezone.utc).isoformat()
     (guide_dir / "guide.json").write_text(
         json.dumps(guide_data, ensure_ascii=False, indent=2),
         encoding="utf-8",


### PR DESCRIPTION
## Problem

The pipeline was committing in a tight loop — **7,574 `sync: update playing list` commits on 2026-09-05 alone**, roughly one every 2 seconds. 21,852 of the repo's 21,938 commits are this noise.

## Root cause

`assemble()` stamped a fresh `generated_at` on every call:

```python
"generated_at": datetime.now(timezone.utc).isoformat(),
```

So the working tree was dirty on *every* pipeline pass, and `deploy.py`'s "no-op if clean" guard could never fire.

The route loop in `guide_gen.py` compounds it: a route whose file already exists is logged as "already done, skipping" — but control still falls through to `assemble()` + `run_deploy()` at the bottom of the iteration. A fully-generated game therefore emitted **one commit per route, on every pass, forever**. Each diff was a single line:

```diff
-  "generated_at": "2026-09-05T21:20:10.345099+00:00"
+  "generated_at": "2026-09-05T21:20:12.557311+00:00"
```

## Fix

**1. `guide_gen.py` — make `assemble()` idempotent (root cause).**
Compares everything except `generated_at` against the existing file and returns without writing when identical. The timestamp now only advances on a real content change.

**2. `deploy.py` — circuit breaker (defence in depth).**
Refuses to commit when ≥10 sync commits landed in the last 60 min, tunable via `DEPLOY_MAX_SYNC_COMMITS` / `DEPLOY_SYNC_WINDOW_MINUTES`. It lives in `deploy.py` so it covers both the `guide_gen.py` and `review.py` callers, and exits non-zero so `entrypoint.sh`'s `set -e` aborts the pipeline and falls through to its sleep.

## Verification

- Replaying the real `blood-the-last-vampire` loop across all 6 routes leaves `guide.json` **byte-identical** — previously 6 commits per pass.
- `reviewed: true` and `portrait` still survive reassembly (guarded, since `reviewed` gates the review workflow in CLAUDE.md).
- A genuine content change still rewrites, updates `stepCount`, and keeps `generated_at` as the last key.
- Breaker trips at 12 commits/hour, stays out of the way at 3, and a clean tree still no-ops.